### PR TITLE
add infra package for server start and exit handling

### DIFF
--- a/httpserv/httpserv.go
+++ b/httpserv/httpserv.go
@@ -1,0 +1,2 @@
+// Package responsible for all interactions with the HTTP server, such as listen and serve from a http.Server
+package httpserv

--- a/httpserv/run.go
+++ b/httpserv/run.go
@@ -1,4 +1,4 @@
-package infra
+package httpserv
 
 import (
 	"context"

--- a/httpserv/run.go
+++ b/httpserv/run.go
@@ -47,7 +47,7 @@ func handleShutdown(server *http.Server) {
 }
 
 // Listen and serve a http.Handler (for example, chi.NewRouter()) and handles server shutdown
-func RunServer(port int, handler http.Handler) {
+func Run(port int, handler http.Handler) {
 	addr := fmt.Sprintf(":%d", port)
 
 	server := &http.Server{

--- a/infra/server.go
+++ b/infra/server.go
@@ -1,0 +1,63 @@
+package infra
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const (
+	ServerAddress   = ":8000"
+	ShutdownTimeout = 5 * time.Second
+)
+
+func listenAndServe(server *http.Server) {
+	log.Printf("Starting server at address %s\n", server.Addr)
+
+	err := server.ListenAndServe()
+
+	switch {
+	case errors.Is(err, http.ErrServerClosed):
+		log.Println("Server closed")
+	default:
+		log.Fatalf("Error starting server: %s\n", err)
+	}
+}
+
+func handleShutdown(server *http.Server) {
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit // Wait for some syscall errors
+
+	log.Println("Shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("Server could not shutdown gracefully: %v\n", err)
+	}
+
+	log.Println("Server exiting")
+}
+
+// Listen and serve a http.Handler (for example, chi.NewRouter()) and handles server shutdown
+func RunServer(port int, handler http.Handler) {
+	addr := fmt.Sprintf(":%d", port)
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	// Starts server in goroutine so that it won't block the shutdown handling below
+	go listenAndServe(server)
+
+	handleShutdown(server)
+}

--- a/infra/server.go
+++ b/infra/server.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	ServerAddress   = ":8000"
 	ShutdownTimeout = 5 * time.Second
 )
 


### PR DESCRIPTION
Criei uma função `RunServer` que ajuda a tratar erros no `listenAndServe` e lida com shutdowns
do servidor graciosamente

Exemplo de uso:

```go
package main

import (
  "github.com/go-chi/chi"
)

func main() {
  r := chi.NewRouter()

  infra.RunServer(8000, r)
}
```

Fique a vontade para alterar o código e recusar o pull request por qualquer motivo!
